### PR TITLE
Fix practice test start logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,13 @@
             </select>
           </div>
           <button id="startBtn" class="btn btn-primary btn-large">Start Practice</button>
+          
+          <!-- Individual Section Buttons -->
+          <div class="button-group" style="margin-top: 1rem;">
+            <button id="startQuantBtn" class="btn btn-secondary">Start Quant (21)</button>
+            <button id="startVerbalBtn" class="btn btn-secondary">Start Verbal (23)</button>
+            <button id="startDIbtn" class="btn btn-secondary">Start Data Insights (20)</button>
+          </div>
         </div>
 
         <!-- Settings Panel -->


### PR DESCRIPTION
Add dedicated section start buttons and implement static question sampling to fix practice test initiation.

The previous "Practice Test / Start Section" functionality was broken due to reliance on an old adaptive question selection system. This PR replaces that with a new, simpler static logic for starting individual sections, ensuring questions are loaded, sampled, and rendered correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-6829e158-57ea-4809-b006-985996d823e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6829e158-57ea-4809-b006-985996d823e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

